### PR TITLE
添加几个.env变量，方便自部署

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moeflow-frontend",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "dependencies": {
     "@babel/runtime": "^7.12.1",
     "@emotion/babel-preset-css-prop": "^10.0.27",

--- a/public/index.html
+++ b/public/index.html
@@ -5,10 +5,10 @@
     <link rel="icon" href="%PUBLIC_URL%/static/favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1, user-scalable=no, shrink-to-fit=no, viewport-fit=cover"/>
     <meta name="theme-color" content="#000000" />
-    <meta name="description" content="MoeFlow" />
+    <meta name="description" content="%REACT_APP_SITE_NAME%" />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/static/logo192.png" />
     <link rel="manifest" href="%PUBLIC_URL%/static/manifest.json" />
-    <title>MoeFlow</title>
+    <title>%REACT_APP_SITE_NAME%</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -5,6 +5,7 @@ import { useIntl } from 'react-intl';
 import { useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router';
 import { Avatar, Dropdown } from '.';
+import configs from '../configs';
 import { AppState } from '../store';
 import { setUserToken } from '../store/user/slice';
 import style from '../style';
@@ -126,7 +127,7 @@ export const Header: FC<HeaderProps> = ({ className }) => {
             history.push('/');
           }}
         >
-          {formatMessage({ id: 'site.name' })}
+          {configs.siteName || formatMessage({ id: 'site.name' })}
         </div>
       </div>
       {currentUser.token ? (

--- a/src/configs.tsx
+++ b/src/configs.tsx
@@ -1,6 +1,9 @@
 // 公共配置
 const configs = {
   baseURL: process.env.REACT_APP_BASE_URL,
+  siteName: process.env.REACT_APP_SITE_NAME,
+  miitBeiAn: process.env.REACT_APP_BEIAN_NO,
+  siteSlogan: '',
   /** 默认值 */
   default: {
     team: {

--- a/src/configs.tsx
+++ b/src/configs.tsx
@@ -1,9 +1,9 @@
 // 公共配置
 const configs = {
-  baseURL: process.env.REACT_APP_BASE_URL,
-  siteName: process.env.REACT_APP_SITE_NAME,
-  miitBeiAn: process.env.REACT_APP_BEIAN_NO,
-  siteSlogan: '',
+  baseURL: process.env.REACT_APP_BASE_URL, // 后端地址
+  siteName: process.env.REACT_APP_SITE_NAME,  // 网站名称[有填写则覆盖]
+  miitBeiAn: process.env.REACT_APP_BEIAN_NO, // 工信部备案信息[有填写则显示]
+  siteSlogan: '', // 首页标题附加的标语[有填写则覆盖原有标语]
   /** 默认值 */
   default: {
     team: {

--- a/src/hooks/useTitle.ts
+++ b/src/hooks/useTitle.ts
@@ -1,5 +1,6 @@
 import { DependencyList, useEffect } from 'react';
 import { useIntl } from 'react-intl';
+import configs from '../configs';
 
 interface UseTitleParams {
   prefix?: string;
@@ -20,12 +21,13 @@ export const useTitle: UseTitle = (
   deps = []
 ) => {
   const { formatMessage } = useIntl();
+  const siteName = configs.siteName || formatMessage({ id: 'site.name' })
   if (prefix !== '') prefix = prefix + hyphen;
   if (suffix !== '') suffix = hyphen + suffix;
   useEffect(() => {
-    document.title = prefix + formatMessage({ id: 'site.name' }) + suffix;
+    document.title = prefix + siteName + suffix;
     return () => {
-      document.title = formatMessage({ id: 'site.name' });
+      document.title = siteName;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, deps);

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -4,6 +4,7 @@ import { useIntl } from "react-intl";
 import { Header } from "../components";
 import brandJump from "../images/brand/mascot-jump1.png";
 import { FC } from "../interfaces";
+import configs from '../configs';
 import { useTitle } from "../hooks";
 
 /** 首页的属性接口 */
@@ -13,7 +14,7 @@ interface IndexProps {}
  */
 const Index: FC<IndexProps> = () => {
   const { formatMessage } = useIntl(); // i18n
-  useTitle({ suffix: formatMessage({ id: "site.slogan" }) }); // 设置标题
+  useTitle({ suffix: configs.siteSlogan || formatMessage({ id: "site.slogan" }) }); // 设置标题
 
   return (
     <div
@@ -54,7 +55,15 @@ const Index: FC<IndexProps> = () => {
       <div className="Index__Title">
         <img src={brandJump} alt="Mascot" />
       </div>
-      <div className="Index__Footer">{/* 备案号 */}</div>
+      {configs.miitBeiAn ? (
+        <div className="Index__Footer">
+          <a href="https://beian.miit.gov.cn/" target="_blank">{configs.miitBeiAn}</a>
+        </div>
+      ) : (
+        <div className="Index__Footer">
+          {/* 无备案号 */}
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
在`configs.tsx`文件中添加了几个变量，覆盖locales中对应项目的取值。
新增的配置信息：
* `siteName` 网站名称：有填写此变量时，覆盖locales中原有的网站名称
* `miitBeiAn` 备案信息：有填写此变量时，会在首页下方显示符合要求的备案信息
* `siteSlogan`首页标题附加的标语信息：有填写时，会覆盖locales中原有的标语信息

可在`.env`环境变量中配置的：
* `REACT_APP_SITE_NAME` 网站名称：有填写此变量时，覆盖locales中原有的站点名称
* `REACT_APP_BEIAN_NO` 备案信息：有填写此变量时，会在首页下方显示符合要求的备案信息