### PR TITLE
fix: set-admin label in user admin page

### DIFF
--- a/src/components/admin/AdminUserList.tsx
+++ b/src/components/admin/AdminUserList.tsx
@@ -172,8 +172,8 @@ export const AdminUserList: FC<AdminUserListProps> = ({ className }) => {
             }}
           >
             {record.admin
-              ? formatMessage({ id: 'admin.setAdmin' })
-              : formatMessage({ id: 'admin.unsetAdmin' })}
+              ? formatMessage({ id: 'admin.unsetAdmin' })
+              : formatMessage({ id: 'admin.setAdmin' })}
           </a>
           <a
             onClick={() => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the admin user action links to display "Unset Admin" for admins and "Set Admin" for non-admins.

- **Bug Fixes**
	- Improved error handling for fetching data and changing admin status, ensuring clearer error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->